### PR TITLE
Added keeping 1 blank line in declarations

### DIFF
--- a/idea/MTV.xml
+++ b/idea/MTV.xml
@@ -21,6 +21,7 @@
     <option name="SPACES_WITHIN_IMPORTS" value="true" />
   </TypeScriptCodeStyleSettings>
   <codeStyleSettings language="PHP">
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
     <option name="SPACE_AFTER_TYPE_CAST" value="true" />
   </codeStyleSettings>
 </code_scheme>


### PR DESCRIPTION
For auto reformatting files. 
Before this change it is not removing blank lines between functions. It is set to 2 blank lines by default. 